### PR TITLE
feat: regenerate using node.js 12

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -1,14 +1,28 @@
 // Slightly modified version of
 // https://github.com/sindresorhus/proto-props/blob/04fad48f995428eff7e57ab088601a548fc20f2e/generate.js
 
+// The published module can be used from node.js 0.10 but the development scripts require node.js 12+.
 'use strict';
-var fs = require('fs');
-var jsTypes = require('js-types');
+const fs = require('fs');
+const jsTypes = require('js-types');
 
-var ret = jsTypes.reduce(function (acc, cur) {
-	acc[cur] = Object.getOwnPropertyNames(global[cur]).sort();
+const noLegacyProps = [
+	'BigInt',
+	'BigInt64Array',
+	'BigUint64Array',
+	'Promise',
+	'SharedArrayBuffer'
+];
 
-	return acc;
-}, {});
+// eslint-disable-next-line no-use-extend-native/no-use-extend-native
+const ret = Object.fromEntries(jsTypes.map(cur => {
+	// Inject arguments / caller properties where they existed in node.js 10.
+	const fromNode10 = noLegacyProps.includes(cur) ? [] : ['arguments', 'caller'];
+
+	return [
+		cur,
+		fromNode10.concat(Object.getOwnPropertyNames(global[cur])).sort()
+	];
+}));
 
 fs.writeFileSync('obj-props.json', JSON.stringify(ret, null, '\t'));

--- a/obj-props.json
+++ b/obj-props.json
@@ -17,6 +17,25 @@
 		"name",
 		"prototype"
 	],
+	"BigInt": [
+		"asIntN",
+		"asUintN",
+		"length",
+		"name",
+		"prototype"
+	],
+	"BigInt64Array": [
+		"BYTES_PER_ELEMENT",
+		"length",
+		"name",
+		"prototype"
+	],
+	"BigUint64Array": [
+		"BYTES_PER_ELEMENT",
+		"length",
+		"name",
+		"prototype"
+	],
 	"Boolean": [
 		"arguments",
 		"caller",
@@ -134,6 +153,7 @@
 		"defineProperty",
 		"entries",
 		"freeze",
+		"fromEntries",
 		"getOwnPropertyDescriptor",
 		"getOwnPropertyDescriptors",
 		"getOwnPropertyNames",
@@ -194,6 +214,11 @@
 		"name",
 		"prototype"
 	],
+	"SharedArrayBuffer": [
+		"length",
+		"name",
+		"prototype"
+	],
 	"String": [
 		"arguments",
 		"caller",
@@ -206,6 +231,7 @@
 	],
 	"Symbol": [
 		"arguments",
+		"asyncIterator",
 		"caller",
 		"for",
 		"hasInstance",
@@ -214,6 +240,7 @@
 		"keyFor",
 		"length",
 		"match",
+		"matchAll",
 		"name",
 		"prototype",
 		"replace",

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "object"
   ],
   "devDependencies": {
-    "ava": "^0.14.0",
-    "js-types": "^1.0.0",
-    "xo": "*"
+    "ava": "^2.1.0",
+    "js-types": "^2.1.0",
+    "xo": "^0.24.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -2,9 +2,10 @@
 import test from 'ava';
 import objProps from './obj-props';
 
-test(t => {
+test('obj-props', t => {
 	t.true(Object.keys(objProps).length > 0);
 	t.truthy(objProps.Array);
 	t.truthy(objProps.Number);
-	t.true(objProps.Array.indexOf('from') !== -1);
+	t.true(objProps.Array.includes('from'));
+	t.true(objProps.Object.includes('fromEntries'));
 });


### PR DESCRIPTION
The motivation for this PR is to prevent `no-use-extend-native/no-use-extend-native` from throwing an error on `Object.fromEntries`.  If preferred I can remove the re-injection of `arguments` / `caller` but I figured maintaining them would allow this to be a non-breaking change.