### PR TITLE
Get property names from `__proto__` too

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -6,22 +6,16 @@
 const fs = require('fs');
 const jsTypes = require('js-types');
 
-const noLegacyProps = [
-	'BigInt',
-	'BigInt64Array',
-	'BigUint64Array',
-	'Promise',
-	'SharedArrayBuffer'
-];
-
 // eslint-disable-next-line no-use-extend-native/no-use-extend-native
 const ret = Object.fromEntries(jsTypes.map(cur => {
-	// Inject arguments / caller properties where they existed in node.js 10.
-	const fromNode10 = noLegacyProps.includes(cur) ? [] : ['arguments', 'caller'];
-
 	return [
 		cur,
-		fromNode10.concat(Object.getOwnPropertyNames(global[cur])).sort()
+		[
+			...new Set([
+				...Object.getOwnPropertyNames(global[cur]),
+				...Object.getOwnPropertyNames(Reflect.getPrototypeOf(global[cur]))
+			])
+		].sort()
 	];
 }));
 

--- a/generate.js
+++ b/generate.js
@@ -6,7 +6,6 @@
 const fs = require('fs');
 const jsTypes = require('js-types');
 
-// eslint-disable-next-line no-use-extend-native/no-use-extend-native
 const ret = Object.fromEntries(jsTypes.map(cur => {
 	return [
 		cur,

--- a/obj-props.json
+++ b/obj-props.json
@@ -1,127 +1,178 @@
 {
 	"Array": [
+		"apply",
 		"arguments",
+		"bind",
+		"call",
 		"caller",
+		"constructor",
 		"from",
 		"isArray",
 		"length",
 		"name",
 		"of",
-		"prototype"
+		"prototype",
+		"toString"
 	],
 	"ArrayBuffer": [
+		"apply",
 		"arguments",
+		"bind",
+		"call",
 		"caller",
+		"constructor",
 		"isView",
 		"length",
 		"name",
-		"prototype"
+		"prototype",
+		"toString"
 	],
 	"BigInt": [
+		"apply",
+		"arguments",
 		"asIntN",
 		"asUintN",
+		"bind",
+		"call",
+		"caller",
+		"constructor",
 		"length",
 		"name",
-		"prototype"
+		"prototype",
+		"toString"
 	],
 	"BigInt64Array": [
 		"BYTES_PER_ELEMENT",
+		"from",
 		"length",
 		"name",
+		"of",
 		"prototype"
 	],
 	"BigUint64Array": [
 		"BYTES_PER_ELEMENT",
+		"from",
 		"length",
 		"name",
+		"of",
 		"prototype"
 	],
 	"Boolean": [
+		"apply",
 		"arguments",
+		"bind",
+		"call",
 		"caller",
+		"constructor",
 		"length",
 		"name",
-		"prototype"
+		"prototype",
+		"toString"
 	],
 	"DataView": [
+		"apply",
 		"arguments",
+		"bind",
+		"call",
 		"caller",
+		"constructor",
 		"length",
 		"name",
-		"prototype"
+		"prototype",
+		"toString"
 	],
 	"Date": [
 		"UTC",
+		"apply",
 		"arguments",
+		"bind",
+		"call",
 		"caller",
+		"constructor",
 		"length",
 		"name",
 		"now",
 		"parse",
-		"prototype"
+		"prototype",
+		"toString"
 	],
 	"Error": [
+		"apply",
 		"arguments",
+		"bind",
+		"call",
 		"caller",
 		"captureStackTrace",
+		"constructor",
 		"length",
 		"name",
 		"prototype",
-		"stackTraceLimit"
+		"stackTraceLimit",
+		"toString"
 	],
 	"Float32Array": [
 		"BYTES_PER_ELEMENT",
-		"arguments",
-		"caller",
+		"from",
 		"length",
 		"name",
+		"of",
 		"prototype"
 	],
 	"Float64Array": [
 		"BYTES_PER_ELEMENT",
-		"arguments",
-		"caller",
+		"from",
 		"length",
 		"name",
+		"of",
 		"prototype"
 	],
 	"Function": [
+		"apply",
 		"arguments",
+		"bind",
+		"call",
 		"caller",
+		"constructor",
 		"length",
 		"name",
-		"prototype"
+		"prototype",
+		"toString"
 	],
 	"Int16Array": [
 		"BYTES_PER_ELEMENT",
-		"arguments",
-		"caller",
+		"from",
 		"length",
 		"name",
+		"of",
 		"prototype"
 	],
 	"Int32Array": [
 		"BYTES_PER_ELEMENT",
-		"arguments",
-		"caller",
+		"from",
 		"length",
 		"name",
+		"of",
 		"prototype"
 	],
 	"Int8Array": [
 		"BYTES_PER_ELEMENT",
-		"arguments",
-		"caller",
+		"from",
 		"length",
 		"name",
+		"of",
 		"prototype"
 	],
 	"Map": [
+		"apply",
 		"arguments",
+		"bind",
+		"call",
 		"caller",
+		"constructor",
 		"length",
 		"name",
-		"prototype"
+		"prototype",
+		"toString"
 	],
 	"Number": [
 		"EPSILON",
@@ -132,8 +183,12 @@
 		"NEGATIVE_INFINITY",
 		"NaN",
 		"POSITIVE_INFINITY",
+		"apply",
 		"arguments",
+		"bind",
+		"call",
 		"caller",
+		"constructor",
 		"isFinite",
 		"isInteger",
 		"isNaN",
@@ -142,12 +197,17 @@
 		"name",
 		"parseFloat",
 		"parseInt",
-		"prototype"
+		"prototype",
+		"toString"
 	],
 	"Object": [
+		"apply",
 		"arguments",
 		"assign",
+		"bind",
+		"call",
 		"caller",
+		"constructor",
 		"create",
 		"defineProperties",
 		"defineProperty",
@@ -170,16 +230,25 @@
 		"prototype",
 		"seal",
 		"setPrototypeOf",
+		"toString",
 		"values"
 	],
 	"Promise": [
 		"all",
+		"allSettled",
+		"apply",
+		"arguments",
+		"bind",
+		"call",
+		"caller",
+		"constructor",
 		"length",
 		"name",
 		"prototype",
 		"race",
 		"reject",
-		"resolve"
+		"resolve",
+		"toString"
 	],
 	"RegExp": [
 		"$&",
@@ -196,8 +265,12 @@
 		"$9",
 		"$_",
 		"$`",
+		"apply",
 		"arguments",
+		"bind",
+		"call",
 		"caller",
+		"constructor",
 		"input",
 		"lastMatch",
 		"lastParen",
@@ -205,34 +278,56 @@
 		"length",
 		"name",
 		"prototype",
-		"rightContext"
+		"rightContext",
+		"toString"
 	],
 	"Set": [
+		"apply",
 		"arguments",
+		"bind",
+		"call",
 		"caller",
+		"constructor",
 		"length",
 		"name",
-		"prototype"
+		"prototype",
+		"toString"
 	],
 	"SharedArrayBuffer": [
+		"apply",
+		"arguments",
+		"bind",
+		"call",
+		"caller",
+		"constructor",
 		"length",
 		"name",
-		"prototype"
+		"prototype",
+		"toString"
 	],
 	"String": [
+		"apply",
 		"arguments",
+		"bind",
+		"call",
 		"caller",
+		"constructor",
 		"fromCharCode",
 		"fromCodePoint",
 		"length",
 		"name",
 		"prototype",
-		"raw"
+		"raw",
+		"toString"
 	],
 	"Symbol": [
+		"apply",
 		"arguments",
 		"asyncIterator",
+		"bind",
+		"call",
 		"caller",
+		"constructor",
 		"for",
 		"hasInstance",
 		"isConcatSpreadable",
@@ -248,53 +343,64 @@
 		"species",
 		"split",
 		"toPrimitive",
+		"toString",
 		"toStringTag",
 		"unscopables"
 	],
 	"Uint16Array": [
 		"BYTES_PER_ELEMENT",
-		"arguments",
-		"caller",
+		"from",
 		"length",
 		"name",
+		"of",
 		"prototype"
 	],
 	"Uint32Array": [
 		"BYTES_PER_ELEMENT",
-		"arguments",
-		"caller",
+		"from",
 		"length",
 		"name",
+		"of",
 		"prototype"
 	],
 	"Uint8Array": [
 		"BYTES_PER_ELEMENT",
-		"arguments",
-		"caller",
+		"from",
 		"length",
 		"name",
+		"of",
 		"prototype"
 	],
 	"Uint8ClampedArray": [
 		"BYTES_PER_ELEMENT",
-		"arguments",
-		"caller",
+		"from",
 		"length",
 		"name",
+		"of",
 		"prototype"
 	],
 	"WeakMap": [
+		"apply",
 		"arguments",
+		"bind",
+		"call",
 		"caller",
+		"constructor",
 		"length",
 		"name",
-		"prototype"
+		"prototype",
+		"toString"
 	],
 	"WeakSet": [
+		"apply",
 		"arguments",
+		"bind",
+		"call",
 		"caller",
+		"constructor",
 		"length",
 		"name",
-		"prototype"
+		"prototype",
+		"toString"
 	]
 }


### PR DESCRIPTION
This should fix https://github.com/dustinspecker/obj-props/issues/2.

`fromNode10` should not be necessary anymore.

I'm not sure if the added properties (`bind`, `constructor`, `toString`, etc) are a problem or not.